### PR TITLE
use URI#open instead of Kernel#open

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 gem "ruby2d", git: "https://github.com/nakilon/ruby2d", submodules: true
-gem "rubyzip" # to unpack the PressStart2P-Regular.ttf font
+gem "rubyzip", "~>1.3" # to unpack the PressStart2P-Regular.ttf font

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,14 +8,14 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    rubyzip (2.0.0)
+    rubyzip (1.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   ruby2d!
-  rubyzip
+  rubyzip (~> 1.3)
 
 BUNDLED WITH
-   1.17.2
+   2.2.19

--- a/main.rb
+++ b/main.rb
@@ -2,7 +2,7 @@ unless File.exist? "PressStart2P-Regular.ttf"
   require "open-uri"
   require "zip"
   tempfile = Tempfile.new "Press_Start_2P.zip"
-  File.binwrite tempfile, open("https://fonts.google.com/download?family=Press%20Start%202P", &:read)
+  File.binwrite tempfile, URI.open("https://fonts.google.com/download?family=Press%20Start%202P", &:read)
   Zip::File.open(tempfile){ |zip| zip.extract "PressStart2P-Regular.ttf", "PressStart2P-Regular.ttf" }
 end
 

--- a/main.rb
+++ b/main.rb
@@ -2,7 +2,9 @@ unless File.exist? "PressStart2P-Regular.ttf"
   require "open-uri"
   require "zip"
   tempfile = Tempfile.new "Press_Start_2P.zip"
-  File.binwrite tempfile, URI.open("https://fonts.google.com/download?family=Press%20Start%202P", &:read)
+  File.binwrite tempfile, (
+    Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5") ? Kernel : URI
+  ).open("https://fonts.google.com/download?family=Press%20Start%202P", &:read)
   Zip::File.open(tempfile){ |zip| zip.extract "PressStart2P-Regular.ttf", "PressStart2P-Regular.ttf" }
 end
 


### PR DESCRIPTION
Hi.
To make it work with Ruby 3.0, I replaced open with URI.open.
It seems to work fine without replacing it when running with bundler, though.